### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/app/lovely/jsonrpc/proxy.py
+++ b/app/lovely/jsonrpc/proxy.py
@@ -35,7 +35,7 @@ class Session(object):
     _auth = None
 
     def __init__(self, username=None, password=None):
-        self.cookies = Cookie.SmartCookie()
+        self.cookies = Cookie.SimpleCookie()
         if username and password:
             self._auth = {"AUTHORIZATION": "Basic %s" %
                           base64.encodestring("%s:%s" % ('Vorschau', 'Iswwdnsudi10')


### PR DESCRIPTION
SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
For example, the following cookie header would shutdown your proxy:
Set-Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."
